### PR TITLE
Move project details to standalone pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -775,149 +775,6 @@
             }
         }
 
-        /* Modal Styles */
-        .modal_overlay {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0, 0, 0, 0.9);
-            z-index: 1000;
-            opacity: 0;
-            visibility: hidden;
-            transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .modal_overlay.active {
-            opacity: 1;
-            visibility: visible;
-        }
-
-        .modal_content {
-            background: #1a1a1a;
-            border: 1px solid white;
-            border-radius: 24px;
-            max-width: 800px;
-            width: 90%;
-            max-height: 90%;
-            overflow-y: auto;
-            padding: 40px;
-            position: relative;
-            transform: translateY(50px);
-            transition: transform 0.3s ease;
-        }
-
-        .modal_overlay.active .modal_content {
-            transform: translateY(0);
-        }
-
-        .modal_close {
-            position: absolute;
-            top: 20px;
-            right: 20px;
-            background: none;
-            border: none;
-            color: white;
-            font-size: 24px;
-            cursor: pointer;
-            width: 40px;
-            height: 40px;
-            border-radius: 50%;
-            border: 1px solid white;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            transition: all 0.3s ease;
-        }
-
-        .modal_close:hover {
-            background: white;
-            color: black;
-        }
-
-        .modal_title {
-            font-size: 32px;
-            line-height: 38px;
-            margin-bottom: 20px;
-            color: white;
-        }
-
-        .modal_subtitle {
-            font-size: 18px;
-            line-height: 24px;
-            opacity: 0.7;
-            margin-bottom: 30px;
-        }
-
-        .modal_section {
-            margin-bottom: 30px;
-        }
-
-        .modal_section h3 {
-            font-size: 20px;
-            margin-bottom: 15px;
-            color: #00D4AA;
-        }
-
-        .modal_section p {
-            line-height: 24px;
-            margin-bottom: 15px;
-        }
-
-        .modal_metrics {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-            gap: 20px;
-            margin: 20px 0;
-        }
-
-        .metric_item {
-            text-align: center;
-            padding: 20px;
-            border: 1px solid rgba(255, 255, 255, 0.2);
-            border-radius: 12px;
-        }
-
-        .metric_number {
-            font-size: 24px;
-            font-weight: bold;
-            color: #FF6B4A;
-            margin-bottom: 5px;
-        }
-
-        .metric_label {
-            font-size: 14px;
-            opacity: 0.7;
-        }
-
-        @media (max-width: 768px) {
-            .modal_content {
-                padding: 20px;
-                margin: 20px;
-            }
-
-            .modal_title {
-                font-size: 24px;
-                line-height: 28px;
-            }
-
-            .modal_metrics {
-                grid-template-columns: 1fr;
-            }
-        }
-        .cursor_inner {
-            position: fixed;
-            width: 20px;
-            height: 20px;
-            background: white;
-            border-radius: 50%;
-            pointer-events: none;
-            z-index: 9999;
-            transition: transform 0.1s ease;
             mix-blend-mode: difference;
         }
 
@@ -931,234 +788,6 @@
         <div class="cursor_inner"><span></span></div>
     </div>
 
-    <!-- Project Modals -->
-    <div class="modal_overlay" id="modal-yieldstreet">
-        <div class="modal_content">
-            <button class="modal_close">&times;</button>
-            <h2 class="modal_title">Yieldstreet Executive Thought Leadership</h2>
-            <p class="modal_subtitle">Transforming C-suite communication strategy in alternative investments</p>
-            
-            <div class="modal_section">
-                <h3>Challenge</h3>
-                <p>Yieldstreet's executive team needed to establish stronger thought leadership positioning in the competitive fintech space. Previous communications lacked strategic focus and failed to leverage the unique expertise of leadership.</p>
-            </div>
-
-            <div class="modal_section">
-                <h3>Strategy</h3>
-                <p>Developed a comprehensive executive narrative strategy focusing on alternative investment expertise, market insights, and democratization of private markets. Created content pillars around market trends, investor education, and regulatory perspectives.</p>
-            </div>
-
-            <div class="modal_metrics">
-                <div class="metric_item">
-                    <div class="metric_number">70%</div>
-                    <div class="metric_label">LinkedIn Growth</div>
-                </div>
-                <div class="metric_item">
-                    <div class="metric_number">30%</div>
-                    <div class="metric_label">Tier-One Placements</div>
-                </div>
-                <div class="metric_item">
-                    <div class="metric_number">5+</div>
-                    <div class="metric_label">Published Op-Eds</div>
-                </div>
-            </div>
-
-            <div class="modal_section">
-                <h3>Impact</h3>
-                <p>Successfully positioned leadership as industry experts, resulting in increased speaking opportunities, media requests, and enhanced brand credibility in the alternative investment space.</p>
-            </div>
-        </div>
-    </div>
-
-    <div class="modal_overlay" id="modal-cadre">
-        <div class="modal_content">
-            <button class="modal_close">&times;</button>
-            <h2 class="modal_title">Cadre Acquisition Communications</h2>
-            <p class="modal_subtitle">Strategic communications for major real estate tech acquisition</p>
-            
-            <div class="modal_section">
-                <h3>Challenge</h3>
-                <p>Managing external communications for Yieldstreet's acquisition of Cadre required careful messaging to multiple stakeholder groups while maintaining market confidence and regulatory compliance.</p>
-            </div>
-
-            <div class="modal_section">
-                <h3>Strategy</h3>
-                <p>Orchestrated a multi-channel communications approach including press releases, executive interviews, and targeted media outreach. Developed distinct messaging for investors, clients, and industry press.</p>
-            </div>
-
-            <div class="modal_metrics">
-                <div class="metric_item">
-                    <div class="metric_number">15+</div>
-                    <div class="metric_label">Media Outlets</div>
-                </div>
-                <div class="metric_item">
-                    <div class="metric_number">100%</div>
-                    <div class="metric_label">Positive Coverage</div>
-                </div>
-                <div class="metric_item">
-                    <div class="metric_number">48hrs</div>
-                    <div class="metric_label">Response Time</div>
-                </div>
-            </div>
-
-            <div class="modal_section">
-                <h3>Results</h3>
-                <p>Secured positive coverage across TechCrunch, The Wall Street Journal, and other tier-one publications. Successfully positioned the acquisition as strategic expansion rather than defensive move.</p>
-            </div>
-        </div>
-    </div>
-
-    <div class="modal_overlay" id="modal-investment">
-        <div class="modal_content">
-            <button class="modal_close">&times;</button>
-            <h2 class="modal_title">Data-Driven Investment Narratives</h2>
-            <p class="modal_subtitle">Transforming complex financial data into compelling stories</p>
-            
-            <div class="modal_section">
-                <h3>Approach</h3>
-                <p>Collaborated directly with investment teams to translate complex market analysis and portfolio performance data into accessible, engaging content for multiple audience segments.</p>
-            </div>
-
-            <div class="modal_section">
-                <h3>Content Development</h3>
-                <p>Created quarterly investment insights, market commentary, and educational content that balanced technical accuracy with narrative appeal. Developed visual storytelling frameworks to enhance data comprehension.</p>
-            </div>
-
-            <div class="modal_metrics">
-                <div class="metric_item">
-                    <div class="metric_number">40%</div>
-                    <div class="metric_label">Email Engagement</div>
-                </div>
-                <div class="metric_item">
-                    <div class="metric_number">25+</div>
-                    <div class="metric_label">Content Pieces</div>
-                </div>
-                <div class="metric_item">
-                    <div class="metric_number">3</div>
-                    <div class="metric_label">Investment Teams</div>
-                </div>
-            </div>
-
-            <div class="modal_section">
-                <h3>Impact</h3>
-                <p>Significantly improved client engagement with investment content, leading to increased retention and deeper client relationships. Content framework adopted across multiple investment verticals.</p>
-            </div>
-        </div>
-    </div>
-
-    <div class="modal_overlay" id="modal-urban">
-        <div class="modal_content">
-            <button class="modal_close">&times;</button>
-            <h2 class="modal_title">Urban Pathways Media Strategy</h2>
-            <p class="modal_subtitle">Elevating nonprofit visibility through strategic media relations</p>
-            
-            <div class="modal_section">
-                <h3>Challenge</h3>
-                <p>Urban Pathways needed increased visibility among city agencies and donors to support their housing and social services mission. Limited media presence hindered fundraising and advocacy efforts.</p>
-            </div>
-
-            <div class="modal_section">
-                <h3>Strategy</h3>
-                <p>Built comprehensive media relations strategy targeting local NYC outlets, policy reporters, and social impact journalists. Developed data-driven story angles highlighting program outcomes and client success stories.</p>
-            </div>
-
-            <div class="modal_metrics">
-                <div class="metric_item">
-                    <div class="metric_number">50+</div>
-                    <div class="metric_label">Media Placements</div>
-                </div>
-                <div class="metric_item">
-                    <div class="metric_number">80%</div>
-                    <div class="metric_label">Donor Engagement</div>
-                </div>
-                <div class="metric_item">
-                    <div class="metric_number">4</div>
-                    <div class="metric_label">Team Members</div>
-                </div>
-            </div>
-
-            <div class="modal_section">
-                <h3>Results</h3>
-                <p>Generated coverage across CNN, NY1, Gothamist, and Crain's New York. Contributed to substantial increase in donor engagement and enhanced organizational credibility with city agencies.</p>
-            </div>
-        </div>
-    </div>
-
-    <div class="modal_overlay" id="modal-tech">
-        <div class="modal_content">
-            <button class="modal_close">&times;</button>
-            <h2 class="modal_title">Tech Executive Storytelling</h2>
-            <p class="modal_subtitle">Content strategy for C-level technology leaders</p>
-            
-            <div class="modal_section">
-                <h3>Client Portfolio</h3>
-                <p>Managed thought leadership programs for 6+ C-level executives across emerging technology companies, serving as primary strategic contact for messaging alignment and content development.</p>
-            </div>
-
-            <div class="modal_section">
-                <h3>Specialization</h3>
-                <p>Developed expertise in narrative design for complex technical themes, transforming dense technological concepts into compelling, media-ready content that enhanced executive positioning and stakeholder engagement.</p>
-            </div>
-
-            <div class="modal_metrics">
-                <div class="metric_item">
-                    <div class="metric_number">6+</div>
-                    <div class="metric_label">C-Level Clients</div>
-                </div>
-                <div class="metric_item">
-                    <div class="metric_number">85%</div>
-                    <div class="metric_label">Client Retention</div>
-                </div>
-                <div class="metric_item">
-                    <div class="metric_number">200+</div>
-                    <div class="metric_label">Content Pieces</div>
-                </div>
-            </div>
-
-            <div class="modal_section">
-                <h3>Approach</h3>
-                <p>Implemented metrics dashboard using Meltwater and Cision to evaluate messaging impact, ensuring data-driven optimization of thought leadership strategies across technology sector clients.</p>
-            </div>
-        </div>
-    </div>
-
-    <div class="modal_overlay" id="modal-political">
-        <div class="modal_content">
-            <button class="modal_close">&times;</button>
-            <h2 class="modal_title">Political Campaign Messaging</h2>
-            <p class="modal_subtitle">Strategic communications for congressional campaign</p>
-            
-            <div class="modal_section">
-                <h3>Role</h3>
-                <p>Served as Deputy Press Secretary and Speechwriter for Jackie Gordon's congressional campaign, managing media relations and developing core messaging during high-stakes political race.</p>
-            </div>
-
-            <div class="modal_section">
-                <h3>Responsibilities</h3>
-                <p>Acted as primary liaison for media requests, coordinated press events, and managed rapid response communications to maintain campaign messaging integrity throughout election cycle.</p>
-            </div>
-
-            <div class="modal_metrics">
-                <div class="metric_item">
-                    <div class="metric_number">20+</div>
-                    <div class="metric_label">Speeches Written</div>
-                </div>
-                <div class="metric_item">
-                    <div class="metric_number">5+</div>
-                    <div class="metric_label">Live Broadcasts</div>
-                </div>
-                <div class="metric_item">
-                    <div class="metric_number">24/7</div>
-                    <div class="metric_label">Response Capability</div>
-                </div>
-            </div>
-
-            <div class="modal_section">
-                <h3>Impact</h3>
-                <p>Drafted debate scripts and campaign speeches broadcast live on local and regional networks. Maintained consistent messaging discipline while adapting to rapidly evolving political landscape.</p>
-            </div>
-        </div>
-    </div>
 
     <div id="site_container" class="desktop_version">
         <div id="page" class="hfeed site">
@@ -1196,7 +825,7 @@
                 <div class="main_grid_container">
                     <div class="main_grid clear">
                         <div class="grid_item">
-                            <a href="#" data-aos="fade-up" data-modal="yieldstreet">
+                            <a href="projects/yieldstreet.html" data-aos="fade-up">
                                 <div class="grid_item_image">
                                     <div class="grid_item_image_ob" style="background: linear-gradient(135deg, #2D5BFF, #4B7BFF);"></div>
                                 </div>
@@ -1208,7 +837,7 @@
                         </div>
 
                         <div class="grid_item">
-                            <a href="#" data-aos="fade-up" data-aos-delay="100" data-modal="cadre">
+                            <a href="projects/cadre.html" data-aos="fade-up" data-aos-delay="100">
                                 <div class="grid_item_image">
                                     <div class="grid_item_image_ob" style="background: linear-gradient(135deg, #FF6B4A, #FF8E53);"></div>
                                 </div>
@@ -1220,7 +849,7 @@
                         </div>
 
                         <div class="grid_item">
-                            <a href="#" data-aos="fade-up" data-aos-delay="200" data-modal="investment">
+                            <a href="projects/investment.html" data-aos="fade-up" data-aos-delay="200">
                                 <div class="grid_item_image">
                                     <div class="grid_item_image_ob" style="background: linear-gradient(135deg, #00D4AA, #26E0C6);"></div>
                                 </div>
@@ -1232,7 +861,7 @@
                         </div>
 
                         <div class="grid_item">
-                            <a href="#" data-aos="fade-up" data-modal="urban">
+                            <a href="projects/urban.html" data-aos="fade-up">
                                 <div class="grid_item_image">
                                     <div class="grid_item_image_ob" style="background: linear-gradient(135deg, #7C4DFF, #9C27B0);"></div>
                                 </div>
@@ -1244,7 +873,7 @@
                         </div>
 
                         <div class="grid_item">
-                            <a href="#" data-aos="fade-up" data-aos-delay="100" data-modal="tech">
+                            <a href="projects/tech.html" data-aos="fade-up" data-aos-delay="100">
                                 <div class="grid_item_image">
                                     <div class="grid_item_image_ob" style="background: linear-gradient(135deg, #FF9800, #FFC107);"></div>
                                 </div>
@@ -1256,7 +885,7 @@
                         </div>
 
                         <div class="grid_item">
-                            <a href="#" data-aos="fade-up" data-aos-delay="200" data-modal="political">
+                            <a href="projects/political.html" data-aos="fade-up" data-aos-delay="200">
                                 <div class="grid_item_image">
                                     <div class="grid_item_image_ob" style="background: linear-gradient(135deg, #E91E63, #F06292);"></div>
                                 </div>
@@ -1442,95 +1071,8 @@
             elements.forEach(el => {
                 observer.observe(el);
             });
+
         }
-
-        // Filter functionality - removed since filters are deleted
-        // const filterItems = document.querySelectorAll('.filter_item');
-        // const gridItems = document.querySelectorAll('.grid_item');
-
-        // Modal functionality
-        function initModals() {
-            try {
-                const modalTriggers = document.querySelectorAll('[data-modal]');
-                const modals = document.querySelectorAll('.modal_overlay');
-                const closeButtons = document.querySelectorAll('.modal_close');
-
-                // Open modal
-                modalTriggers.forEach(trigger => {
-                    trigger.addEventListener('click', function(e) {
-                        e.preventDefault();
-                        const modalId = this.getAttribute('data-modal');
-                        const modal = document.getElementById(`modal-${modalId}`);
-                        if (modal) {
-                            modal.classList.add('active');
-                            document.body.style.overflow = 'hidden';
-                        }
-                    });
-                });
-
-                // Close modal
-                closeButtons.forEach(button => {
-                    button.addEventListener('click', function() {
-                        const modal = this.closest('.modal_overlay');
-                        if (modal) {
-                            modal.classList.remove('active');
-                            document.body.style.overflow = 'auto';
-                        }
-                    });
-                });
-
-                // Close modal when clicking overlay
-                modals.forEach(modal => {
-                    modal.addEventListener('click', function(e) {
-                        if (e.target === this) {
-                            this.classList.remove('active');
-                            document.body.style.overflow = 'auto';
-                        }
-                    });
-                });
-
-                // Close modal with escape key
-                document.addEventListener('keydown', function(e) {
-                    if (e.key === 'Escape') {
-                        const activeModal = document.querySelector('.modal_overlay.active');
-                        if (activeModal) {
-                            activeModal.classList.remove('active');
-                            document.body.style.overflow = 'auto';
-                        }
-                    }
-                });
-            } catch (e) {
-                console.warn('Modal initialization error:', e);
-            }
-        }
-        const newsletterForm = document.querySelector('.newsletter_form');
-        if (newsletterForm) {
-            newsletterForm.addEventListener('submit', function(e) {
-                e.preventDefault();
-                const email = this.querySelector('.newsletter_email').value;
-                if (email) {
-                    alert('Thank you for subscribing!');
-                    this.reset();
-                }
-            });
-        }
-
-        // Grid item hover effects for mobile
-        if (isMobile) {
-            gridItems.forEach(item => {
-                item.addEventListener('touchstart', function() {
-                    this.classList.add('mobile_hover');
-                });
-                
-                item.addEventListener('touchend', function() {
-                    setTimeout(() => {
-                        this.classList.remove('mobile_hover');
-                    }, 200);
-                });
-            });
-        }
-
-        // Initialize animations when DOM is loaded
         document.addEventListener('DOMContentLoaded', function() {
             initAOS();
             

--- a/projects/cadre.html
+++ b/projects/cadre.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Cadre Acquisition Communications</title>
+    <style>
+        body {background:#000;color:white;font-family:Helvetica,Helvetica Neue,Arial;margin:0;padding:40px;}
+        a{color:white;}
+        .modal_content {background:#1a1a1a;border:1px solid white;border-radius:24px;max-width:800px;margin:auto;padding:40px;}
+        .modal_title {font-size:32px;line-height:38px;margin-bottom:20px;}
+        .modal_subtitle {font-size:18px;line-height:24px;opacity:0.7;margin-bottom:30px;}
+        .modal_section {margin-bottom:30px;}
+        .modal_section h3 {font-size:20px;margin-bottom:15px;color:#00D4AA;}
+        .modal_section p {line-height:24px;margin-bottom:15px;}
+        .modal_metrics {display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:20px;margin:20px 0;}
+        .metric_item {text-align:center;padding:20px;border:1px solid rgba(255,255,255,0.2);border-radius:12px;}
+        .metric_number {font-size:24px;font-weight:bold;color:#FF6B4A;margin-bottom:5px;}
+        .metric_label {font-size:14px;opacity:0.7;}
+    </style>
+</head>
+<body>
+<a href="../index.html">&larr; Back</a>
+<div class="modal_content">
+<h2 class="modal_title">Cadre Acquisition Communications</h2>
+<p class="modal_subtitle">Strategic communications for major real estate tech acquisition</p>
+<div class="modal_section">
+<h3>Challenge</h3>
+<p>Managing external communications for Yieldstreet's acquisition of Cadre required careful messaging to multiple stakeholder groups while maintaining market confidence and regulatory compliance.</p>
+</div>
+<div class="modal_section">
+<h3>Strategy</h3>
+<p>Orchestrated a multi-channel communications approach including press releases, executive interviews, and targeted media outreach. Developed distinct messaging for investors, clients, and industry press.</p>
+</div>
+<div class="modal_metrics">
+<div class="metric_item">
+<div class="metric_number">15+</div>
+<div class="metric_label">Media Outlets</div>
+</div>
+<div class="metric_item">
+<div class="metric_number">100%</div>
+<div class="metric_label">Positive Coverage</div>
+</div>
+<div class="metric_item">
+<div class="metric_number">48hrs</div>
+<div class="metric_label">Response Time</div>
+</div>
+</div>
+<div class="modal_section">
+<h3>Results</h3>
+<p>Secured positive coverage across TechCrunch, The Wall Street Journal, and other tier-one publications. Successfully positioned the acquisition as strategic expansion rather than defensive move.</p>
+</div>
+</div>
+</body>
+</html>

--- a/projects/investment.html
+++ b/projects/investment.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Data-Driven Investment Narratives</title>
+    <style>
+        body {background:#000;color:white;font-family:Helvetica,Helvetica Neue,Arial;margin:0;padding:40px;}
+        a{color:white;}
+        .modal_content {background:#1a1a1a;border:1px solid white;border-radius:24px;max-width:800px;margin:auto;padding:40px;}
+        .modal_title {font-size:32px;line-height:38px;margin-bottom:20px;}
+        .modal_subtitle {font-size:18px;line-height:24px;opacity:0.7;margin-bottom:30px;}
+        .modal_section {margin-bottom:30px;}
+        .modal_section h3 {font-size:20px;margin-bottom:15px;color:#00D4AA;}
+        .modal_section p {line-height:24px;margin-bottom:15px;}
+        .modal_metrics {display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:20px;margin:20px 0;}
+        .metric_item {text-align:center;padding:20px;border:1px solid rgba(255,255,255,0.2);border-radius:12px;}
+        .metric_number {font-size:24px;font-weight:bold;color:#FF6B4A;margin-bottom:5px;}
+        .metric_label {font-size:14px;opacity:0.7;}
+    </style>
+</head>
+<body>
+<a href="../index.html">&larr; Back</a>
+<div class="modal_content">
+<h2 class="modal_title">Data-Driven Investment Narratives</h2>
+<p class="modal_subtitle">Transforming complex financial data into compelling stories</p>
+<div class="modal_section">
+<h3>Approach</h3>
+<p>Collaborated directly with investment teams to translate complex market analysis and portfolio performance data into accessible, engaging content for multiple audience segments.</p>
+</div>
+<div class="modal_section">
+<h3>Content Development</h3>
+<p>Created quarterly investment insights, market commentary, and educational content that balanced technical accuracy with narrative appeal. Developed visual storytelling frameworks to enhance data comprehension.</p>
+</div>
+<div class="modal_metrics">
+<div class="metric_item">
+<div class="metric_number">40%</div>
+<div class="metric_label">Email Engagement</div>
+</div>
+<div class="metric_item">
+<div class="metric_number">25+</div>
+<div class="metric_label">Content Pieces</div>
+</div>
+<div class="metric_item">
+<div class="metric_number">3</div>
+<div class="metric_label">Investment Teams</div>
+</div>
+</div>
+<div class="modal_section">
+<h3>Impact</h3>
+<p>Significantly improved client engagement with investment content, leading to increased retention and deeper client relationships. Content framework adopted across multiple investment verticals.</p>
+</div>
+</div>
+</body>
+</html>

--- a/projects/political.html
+++ b/projects/political.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Political Campaign Messaging</title>
+    <style>
+        body {background:#000;color:white;font-family:Helvetica,Helvetica Neue,Arial;margin:0;padding:40px;}
+        a{color:white;}
+        .modal_content {background:#1a1a1a;border:1px solid white;border-radius:24px;max-width:800px;margin:auto;padding:40px;}
+        .modal_title {font-size:32px;line-height:38px;margin-bottom:20px;}
+        .modal_subtitle {font-size:18px;line-height:24px;opacity:0.7;margin-bottom:30px;}
+        .modal_section {margin-bottom:30px;}
+        .modal_section h3 {font-size:20px;margin-bottom:15px;color:#00D4AA;}
+        .modal_section p {line-height:24px;margin-bottom:15px;}
+        .modal_metrics {display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:20px;margin:20px 0;}
+        .metric_item {text-align:center;padding:20px;border:1px solid rgba(255,255,255,0.2);border-radius:12px;}
+        .metric_number {font-size:24px;font-weight:bold;color:#FF6B4A;margin-bottom:5px;}
+        .metric_label {font-size:14px;opacity:0.7;}
+    </style>
+</head>
+<body>
+<a href="../index.html">&larr; Back</a>
+<div class="modal_content">
+<h2 class="modal_title">Political Campaign Messaging</h2>
+<p class="modal_subtitle">Strategic communications for congressional campaign</p>
+<div class="modal_section">
+<h3>Role</h3>
+<p>Served as Deputy Press Secretary and Speechwriter for Jackie Gordon's congressional campaign, managing media relations and developing core messaging during high-stakes political race.</p>
+</div>
+<div class="modal_section">
+<h3>Responsibilities</h3>
+<p>Acted as primary liaison for media requests, coordinated press events, and managed rapid response communications to maintain campaign messaging integrity throughout election cycle.</p>
+</div>
+<div class="modal_metrics">
+<div class="metric_item">
+<div class="metric_number">20+</div>
+<div class="metric_label">Speeches Written</div>
+</div>
+<div class="metric_item">
+<div class="metric_number">5+</div>
+<div class="metric_label">Live Broadcasts</div>
+</div>
+<div class="metric_item">
+<div class="metric_number">24/7</div>
+<div class="metric_label">Response Capability</div>
+</div>
+</div>
+<div class="modal_section">
+<h3>Impact</h3>
+<p>Drafted debate scripts and campaign speeches broadcast live on local and regional networks. Maintained consistent messaging discipline while adapting to rapidly evolving political landscape.</p>
+</div>
+</div>
+</body>
+</html>

--- a/projects/tech.html
+++ b/projects/tech.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Tech Executive Storytelling</title>
+    <style>
+        body {background:#000;color:white;font-family:Helvetica,Helvetica Neue,Arial;margin:0;padding:40px;}
+        a{color:white;}
+        .modal_content {background:#1a1a1a;border:1px solid white;border-radius:24px;max-width:800px;margin:auto;padding:40px;}
+        .modal_title {font-size:32px;line-height:38px;margin-bottom:20px;}
+        .modal_subtitle {font-size:18px;line-height:24px;opacity:0.7;margin-bottom:30px;}
+        .modal_section {margin-bottom:30px;}
+        .modal_section h3 {font-size:20px;margin-bottom:15px;color:#00D4AA;}
+        .modal_section p {line-height:24px;margin-bottom:15px;}
+        .modal_metrics {display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:20px;margin:20px 0;}
+        .metric_item {text-align:center;padding:20px;border:1px solid rgba(255,255,255,0.2);border-radius:12px;}
+        .metric_number {font-size:24px;font-weight:bold;color:#FF6B4A;margin-bottom:5px;}
+        .metric_label {font-size:14px;opacity:0.7;}
+    </style>
+</head>
+<body>
+<a href="../index.html">&larr; Back</a>
+<div class="modal_content">
+<h2 class="modal_title">Tech Executive Storytelling</h2>
+<p class="modal_subtitle">Content strategy for C-level technology leaders</p>
+<div class="modal_section">
+<h3>Client Portfolio</h3>
+<p>Managed thought leadership programs for 6+ C-level executives across emerging technology companies, serving as primary strategic contact for messaging alignment and content development.</p>
+</div>
+<div class="modal_section">
+<h3>Specialization</h3>
+<p>Developed expertise in narrative design for complex technical themes, transforming dense technological concepts into compelling, media-ready content that enhanced executive positioning and stakeholder engagement.</p>
+</div>
+<div class="modal_metrics">
+<div class="metric_item">
+<div class="metric_number">6+</div>
+<div class="metric_label">C-Level Clients</div>
+</div>
+<div class="metric_item">
+<div class="metric_number">85%</div>
+<div class="metric_label">Client Retention</div>
+</div>
+<div class="metric_item">
+<div class="metric_number">200+</div>
+<div class="metric_label">Content Pieces</div>
+</div>
+</div>
+<div class="modal_section">
+<h3>Approach</h3>
+<p>Implemented metrics dashboard using Meltwater and Cision to evaluate messaging impact, ensuring data-driven optimization of thought leadership strategies across technology sector clients.</p>
+</div>
+</div>
+</body>
+</html>

--- a/projects/urban.html
+++ b/projects/urban.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Urban Pathways Media Strategy</title>
+    <style>
+        body {background:#000;color:white;font-family:Helvetica,Helvetica Neue,Arial;margin:0;padding:40px;}
+        a{color:white;}
+        .modal_content {background:#1a1a1a;border:1px solid white;border-radius:24px;max-width:800px;margin:auto;padding:40px;}
+        .modal_title {font-size:32px;line-height:38px;margin-bottom:20px;}
+        .modal_subtitle {font-size:18px;line-height:24px;opacity:0.7;margin-bottom:30px;}
+        .modal_section {margin-bottom:30px;}
+        .modal_section h3 {font-size:20px;margin-bottom:15px;color:#00D4AA;}
+        .modal_section p {line-height:24px;margin-bottom:15px;}
+        .modal_metrics {display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:20px;margin:20px 0;}
+        .metric_item {text-align:center;padding:20px;border:1px solid rgba(255,255,255,0.2);border-radius:12px;}
+        .metric_number {font-size:24px;font-weight:bold;color:#FF6B4A;margin-bottom:5px;}
+        .metric_label {font-size:14px;opacity:0.7;}
+    </style>
+</head>
+<body>
+<a href="../index.html">&larr; Back</a>
+<div class="modal_content">
+<h2 class="modal_title">Urban Pathways Media Strategy</h2>
+<p class="modal_subtitle">Elevating nonprofit visibility through strategic media relations</p>
+<div class="modal_section">
+<h3>Challenge</h3>
+<p>Urban Pathways needed increased visibility among city agencies and donors to support their housing and social services mission. Limited media presence hindered fundraising and advocacy efforts.</p>
+</div>
+<div class="modal_section">
+<h3>Strategy</h3>
+<p>Built comprehensive media relations strategy targeting local NYC outlets, policy reporters, and social impact journalists. Developed data-driven story angles highlighting program outcomes and client success stories.</p>
+</div>
+<div class="modal_metrics">
+<div class="metric_item">
+<div class="metric_number">50+</div>
+<div class="metric_label">Media Placements</div>
+</div>
+<div class="metric_item">
+<div class="metric_number">80%</div>
+<div class="metric_label">Donor Engagement</div>
+</div>
+<div class="metric_item">
+<div class="metric_number">4</div>
+<div class="metric_label">Team Members</div>
+</div>
+</div>
+<div class="modal_section">
+<h3>Results</h3>
+<p>Generated coverage across CNN, NY1, Gothamist, and Crain's New York. Contributed to substantial increase in donor engagement and enhanced organizational credibility with city agencies.</p>
+</div>
+</div>
+</body>
+</html>

--- a/projects/yieldstreet.html
+++ b/projects/yieldstreet.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Yieldstreet Executive Thought Leadership</title>
+    <style>
+        body {background:#000;color:white;font-family:Helvetica,Helvetica Neue,Arial;margin:0;padding:40px;}
+        a{color:white;}
+        .modal_content {background:#1a1a1a;border:1px solid white;border-radius:24px;max-width:800px;margin:auto;padding:40px;}
+        .modal_title {font-size:32px;line-height:38px;margin-bottom:20px;}
+        .modal_subtitle {font-size:18px;line-height:24px;opacity:0.7;margin-bottom:30px;}
+        .modal_section {margin-bottom:30px;}
+        .modal_section h3 {font-size:20px;margin-bottom:15px;color:#00D4AA;}
+        .modal_section p {line-height:24px;margin-bottom:15px;}
+        .modal_metrics {display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:20px;margin:20px 0;}
+        .metric_item {text-align:center;padding:20px;border:1px solid rgba(255,255,255,0.2);border-radius:12px;}
+        .metric_number {font-size:24px;font-weight:bold;color:#FF6B4A;margin-bottom:5px;}
+        .metric_label {font-size:14px;opacity:0.7;}
+    </style>
+</head>
+<body>
+<a href="../index.html">&larr; Back</a>
+<div class="modal_content">
+<h2 class="modal_title">Yieldstreet Executive Thought Leadership</h2>
+<p class="modal_subtitle">Transforming C-suite communication strategy in alternative investments</p>
+<div class="modal_section">
+<h3>Challenge</h3>
+<p>Yieldstreet's executive team needed to establish stronger thought leadership positioning in the competitive fintech space. Previous communications lacked strategic focus and failed to leverage the unique expertise of leadership.</p>
+</div>
+<div class="modal_section">
+<h3>Strategy</h3>
+<p>Developed a comprehensive executive narrative strategy focusing on alternative investment expertise, market insights, and democratization of private markets. Created content pillars around market trends, investor education, and regulatory perspectives.</p>
+</div>
+<div class="modal_metrics">
+<div class="metric_item">
+<div class="metric_number">70%</div>
+<div class="metric_label">LinkedIn Growth</div>
+</div>
+<div class="metric_item">
+<div class="metric_number">30%</div>
+<div class="metric_label">Tier-One Placements</div>
+</div>
+<div class="metric_item">
+<div class="metric_number">5+</div>
+<div class="metric_label">Published Op-Eds</div>
+</div>
+</div>
+<div class="modal_section">
+<h3>Impact</h3>
+<p>Successfully positioned leadership as industry experts, resulting in increased speaking opportunities, media requests, and enhanced brand credibility in the alternative investment space.</p>
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extract each project modal into separate HTML pages in `projects/`
- link grid items directly to these pages
- strip modal HTML, styles and scripts from the homepage

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68673892ea48832da22e57e7750ac8b6